### PR TITLE
Improve merging of d0 bettis

### DIFF
--- a/LHFmain/main.cpp
+++ b/LHFmain/main.cpp
@@ -90,7 +90,7 @@
 	}	
 
 	void processReducedWrapper(std::map<std::string, std::string> args, pipePacket* wD){
-		
+		auto maxEpsilon = std::atof(args["epsilon"].c_str());
 		auto *ws = new writeOutput();
 		std::vector<bettiBoundaryTableEntry> mergedBettiTable;
 		
@@ -150,18 +150,12 @@
 				//Utilize a vector of bools to track connected components, size of the partition
 				std::vector<bool> conTrack(partitionedData.second[z].size(), false);
 				bool foundExt = false;
-								
+				unsigned tempIndex;		
+				
 				for(auto betEntry : wD->bettiTable){
-					std::cout << "Evaluating betti entry: " << betEntry.bettiDim << ", " << betEntry.birth << ", " << betEntry.death << "\t";
-					ut.print1DVector(betEntry.boundaryPoints);
-					std::cout << "BP size: " << betEntry.boundaryPoints.size() << std::endl;
-					
-					for(auto z : conTrack)
-						std::cout << z << " ";
-					std::cout << std::endl;
 					
 					auto boundIter = betEntry.boundaryPoints.begin();
-					unsigned tempIndex;
+					
 					//The new (improved) approach to merging d0 bettis (pretty sure this works....)
 					//	1. Use a binary array to track each point within the original partition
 					//	2. Iterate the betti entries by weight, increasing
@@ -174,11 +168,9 @@
 					//		-If (b) was not traversed, need to add a {0, maxEps} entry for the independent component (Check this?)
 					
 					if(betEntry.bettiDim == 0 && betEntry.boundaryPoints.size() > 1){	
-								
 						if(betEntry.boundaryPoints.size() > 0 && (*boundIter) < binCounts[z]){
 							tempIndex = (*boundIter);
 							boundIter++;
-							std::cout << "insA" << std::endl;
 							
 							//Check if second entry is in the partition
 							if((*boundIter) < binCounts[z]){
@@ -194,15 +186,17 @@
 								conTrack[tempIndex] = true, conTrack[(*boundIter)] = true;
 							}
 						}
-						
-						
-						
-						
 					} else if(betEntry.bettiDim > 0 && betEntry.boundaryPoints.size() > 0 && *(betEntry.boundaryPoints.begin()) < binCounts[z]){
 						mergedBettiTable.push_back(betEntry);
 					}
-					
 				}
+				//If we never found an external connection, add the infinite connection here
+				if(!foundExt){
+					bettiBoundaryTableEntry des = { 0, 0, maxEpsilon, {}, {} };
+					mergedBettiTable.push_back(des);
+				}
+				
+				
 				wD->complex->clear();
 				
 			} else 

--- a/Pipes/fastPersistence.cpp
+++ b/Pipes/fastPersistence.cpp
@@ -103,7 +103,7 @@ pipePacket fastPersistence::runPipe(pipePacket inData){
 			temp->weight = (*edgeIter)->weight;
 			pivots.push_back(temp);
 
-			bettiBoundaryTableEntry des = { 0, 0, (*edgeIter)->weight, {}, {temp} };			
+			bettiBoundaryTableEntry des = { 0, 0, (*edgeIter)->weight, {v1, v2}, {temp} };			
 			inData.bettiTable.push_back(des);
 		}
 


### PR DESCRIPTION
Improved merging of d0 bettis with an interesting approach -- see algorithm description below. It possibly warrants needing the additional points in each partition going up to maxE to determine if two completely separated components ever intersect. This is another possibility we need to add to our lost features scenario.

In that case, if we had two clusters separated by a distance < maxEpsilon but greater than 2*r_max the connection would never form between the two partitioned sets, reporting two open intervals (when there should only be one, and the other one dies somewhere between 2*r_max and maxEpsilon).

Tagging because it's an interesting find - 
@wilseypa @Anindya-Moitra @rishirv @rohitpalsingh 

```
//The new (improved) approach to merging d0 bettis (pretty sure this works....)
//	1. Use a binary array to track each point within the original partition
//	2. Iterate the betti entries by weight, increasing
//		a. If both indices are less than the partition size, check the binary array
//			-If binary array for either of the two indices isn't filled, insert and fill all
//		b. If one index is less than the partition size, the other greater, and this is the first instance of this
//			-Add this to the connection list; this is the minimum connection outside of the partition
//		c. If neither of the indices are less than the partition size, remove
//	3. Once all entries have been iterated - if (b) was traversed there is a connection outside to another partition
//		-If (b) was not traversed, need to add a {0, maxEps} entry for the independent component 
					
```

