### PR TITLE
Stats Updates and debug mode

### DIFF
--- a/LHFmain/LHF.cpp
+++ b/LHFmain/LHF.cpp
@@ -51,6 +51,7 @@ void LHF::runPipeline(std::map<std::string, std::string> args, pipePacket &wD){
 		
 		//For each '.' separated pipeline function (count of '.' + 1 -> lim)
 		for(unsigned i = 0; i < lim; i++){
+			
 			auto curFunct = pipeFuncts.substr(0,pipeFuncts.find('.'));
 			pipeFuncts = pipeFuncts.substr(pipeFuncts.find('.') + 1);
 			//Build the pipe component, configure and run
@@ -83,6 +84,8 @@ void LHF::runPipeline(std::map<std::string, std::string> args, pipePacket &wD){
 		return;
 	}
 	
+	outputBettis(args, wD);
+	
 }
 
 
@@ -99,7 +102,6 @@ void LHF::processDataWrapper(std::map<std::string, std::string> args, pipePacket
 		} else {
 			std::cout << "LHF processData: Failed to configure pipeline: " << args["pipeline"] << std::endl;
 		}
-		
 		delete prePipe;
 	}
 }	

--- a/LHFmain/LHF.cpp
+++ b/LHFmain/LHF.cpp
@@ -95,7 +95,7 @@ void LHF::processDataWrapper(std::map<std::string, std::string> args, pipePacket
 		auto prePipe = preprocessor::newPreprocessor(pre);
 
 		if(prePipe != 0 && prePipe->configPreprocessor(args)){
-			wD = prePipe->runPreprocessorWrapper(wD);
+			prePipe->runPreprocessorWrapper(wD);
 		} else {
 			std::cout << "LHF processData: Failed to configure pipeline: " << args["pipeline"] << std::endl;
 		}

--- a/LHFmain/LHF.cpp
+++ b/LHFmain/LHF.cpp
@@ -13,10 +13,24 @@ void LHF::outputBettis(std::map<std::string, std::string> args, pipePacket &wD){
 	auto pipe = args.find("outputFile");
 	if(pipe != args.end()){
 		if (args["outputFile"] == "console"){
-			//ws->writeConsole(wD);
+			writeOutput::writeConsole(wD.bettiTable);
+			
+			//Check if debug mode for runLog, stats	
+			pipe = args.find("debug");
+			if(pipe != args.end() && args["debug"] == "1"){	
+				writeOutput::writeRunLog(wD.runLog, args["outputFile"]);
+				writeOutput::writeStats(wD.stats, args["outputFile"]);
+			}
+			
 		} else {
-			writeOutput::writeStats(wD.stats, args["outputFile"]);
-			writeOutput::writeBarcodes(wD.bettiTable, args["outputFile"]);	
+			writeOutput::writeBarcodes(wD.bettiTable, args["outputFile"]);
+			
+			//Check if debug mode for runLog, stats	
+			pipe = args.find("debug");
+			if(pipe != args.end() && args["debug"] == "1"){	
+				writeOutput::writeRunLog(wD.runLog, args["outputFile"]);
+				writeOutput::writeStats(wD.stats, args["outputFile"]);
+			}
 		}
 	}
 }
@@ -28,8 +42,12 @@ void LHF::runPipeline(std::map<std::string, std::string> args, pipePacket &wD){
 	auto pipe = args.find("pipeline");
 	
 	if(pipe != args.end()){
+		
 		auto pipeFuncts = std::string(args["pipeline"]);
 		auto lim = count(pipeFuncts.begin(), pipeFuncts.end(), '.') + 1;
+		
+		//Start the timer for time passed during the pipeline
+		auto startTime = std::chrono::high_resolution_clock::now();
 		
 		//For each '.' separated pipeline function (count of '.' + 1 -> lim)
 		for(unsigned i = 0; i < lim; i++){
@@ -47,14 +65,24 @@ void LHF::runPipeline(std::map<std::string, std::string> args, pipePacket &wD){
 			}
 			
 			delete cp;
-			
 		}
+		
+		//Stop the timer for time passed during the pipeline
+		auto endTime = std::chrono::high_resolution_clock::now();
+		
+		//Calculate the duration (physical time) for the pipeline
+		std::chrono::duration<double, std::milli> elapsed = endTime - startTime;
+		
+		//Log the current execution to runLog
+		wD.runLog += writeOutput::logRun(args, wD.ident, wD.getStats(), std::to_string(elapsed.count()/1000.0));
+		
 	}
 	//If the pipeline was undefined...
 	else {
 		std::cout << "LHF runPipeline: Failed to find a suitable pipeline, exiting..." << std::endl;
 		return;
 	}
+	
 }
 
 
@@ -86,6 +114,8 @@ std::vector<bettiBoundaryTableEntry> LHF::processParallel(std::map<std::string, 
 	//		Local Storage
 	std::vector<bettiBoundaryTableEntry> mergedBettiTable;
 	std::vector<bettiBoundaryTableEntry> partBettiTable[threads];
+	std::string runLogs[threads];
+	std::string stats[threads];
 	
 	//		Initalize a copy of the pipePacket
 	auto iterwD = pipePacket(args, args["complexType"]);
@@ -127,14 +157,16 @@ std::vector<bettiBoundaryTableEntry> LHF::processParallel(std::map<std::string, 
 					centArgs["pipeline"] = "distMatrix.neighGraph.incrementalPersistence.upscale";
 				else
 					centArgs["pipeline"] = "distMatrix.neighGraph.incrementalPersistence";
-					
+				
+				iterwD.ident = std::to_string(np) + "," + std::to_string(p);
+				
 				//Run against the original dataset
 			
 				if(partitionedData.second[z].size() > 0){
 					iterwD.inputData = partitionedData.second[z];
 					iterwD.workData = partitionedData.second[z];
 					runPipeline(centArgs, iterwD);
-
+					
 					delete iterwD.complex;
 				} else 
 					std::cout << "skipping full data, no centroids" << std::endl;
@@ -147,6 +179,7 @@ std::vector<bettiBoundaryTableEntry> LHF::processParallel(std::map<std::string, 
 				auto curwD = pipePacket(args, args["complexType"]);	
 				curwD.workData = partitionedData.second[z];
 				curwD.inputData = partitionedData.second[z];
+				curwD.ident = std::to_string(np) + "," + std::to_string(p);
 				
 				//		If the current partition is smaller than the threshold, process
 				//			Otherwise recurse to reduce the number of points
@@ -156,6 +189,9 @@ std::vector<bettiBoundaryTableEntry> LHF::processParallel(std::map<std::string, 
 				} else{
 					runPipeline(args, curwD);
 				}
+				
+				runLogs[np] += curwD.runLog;
+				stats[np] += curwD.stats;
 
 				delete curwD.complex;
 
@@ -251,6 +287,15 @@ std::vector<bettiBoundaryTableEntry> LHF::processParallel(std::map<std::string, 
 		bettiBoundaryTableEntry des = { 0, 0, maxEpsilon, {} };
 		mergedBettiTable.push_back(des);
 	}
+
+	for(auto stat : stats)
+		iterwD.stats += stat;
+		
+	for(auto runLog : runLogs)
+		iterwD.runLog += runLog;
+
+	iterwD.bettiTable = mergedBettiTable;
+	outputBettis(args, iterwD);
 
 	//		Return the final merged betti table for this iteration
 	return mergedBettiTable;
@@ -356,7 +401,7 @@ std::vector<bettiBoundaryTableEntry> LHF::processUpscaleWrapper(std::map<std::st
 	//Minimum Partitions per process
 	int minPartitions=0;
 	
-	//During distribution firstk processes that will receive one more partition than minPartitions
+	//During distribution first k processes that will receive one more partition than minPartitions
 	int firstk=0;
 	
 	//Each Process is aware of fuzzy partition sizes

--- a/LHFmain/main.cpp
+++ b/LHFmain/main.cpp
@@ -82,9 +82,6 @@ int main(int argc, char* argv[]){
 			lhflib.runPipeline(args, wD);
 		}
 
-		//Output the data using writeOutput library
-		lhflib.outputBettis(args, wD);
-
 	} else {
 		argParser::printUsage();
 	}
@@ -101,7 +98,7 @@ int main(int argc, char* argv[]){
 	delete wD.complex;
 
 	double end = omp_get_wtime();
-	std::cout<<"Time in seconds: "<<end-start<<'\n';
+	std::cout << "Total LHF execution time (s): " << end-start << std::endl;
 
 	return 0;
 }

--- a/Pipes/basePipe.cpp
+++ b/Pipes/basePipe.cpp
@@ -57,45 +57,48 @@ void basePipe::runPipeWrapper(pipePacket &inData){
 		std::cout << "Pipe not configured" << std::endl;
 		return;
 	}
-	//Start a timer for physical time passed during the pipe's function
-	auto startTime = std::chrono::high_resolution_clock::now();
 	
-	runPipe(inData);
-	
-	//Stop the timer for time passed during the pipe's function
-	auto endTime = std::chrono::high_resolution_clock::now();
-	
-	//Calculate the duration (physical time) for the pipe's function
-	std::chrono::duration<double, std::milli> elapsed = endTime - startTime;
-	
-	//Output the time and transient memory used for this pipeline segment
-	ut.writeLog(pipeType,"\tPipeline " + pipeType + " executed in " + std::to_string(elapsed.count()/1000.0) + " seconds (physical time)");
-	
-	auto dataSize = inData.getSize();
-	auto unit = "B";
-	
-	//Convert large datatypes (GB, MB, KB)
-	if(dataSize > 1000000000){
-		//Convert to GB
-		dataSize = dataSize/1000000000;
-		unit = "GB";
-	} else if(dataSize > 1000000){
-		//Convert to MB
-		dataSize = dataSize/1000000;
-		unit = "MB";
-	} else if (dataSize > 1000){
-		//Convert to KB
-		dataSize = dataSize/1000;
-		unit = "KB";
-	}
-	
-	inData.stats += pipeType + "," + std::to_string(elapsed.count()/1000.0) + "," + std::to_string(dataSize) + "," + unit + "," + std::to_string(inData.complex->vertexCount()) + "," + std::to_string(inData.complex->simplexCount()) + "\n";
-	
-	std::string ds = std::to_string(dataSize);
-	ut.writeLog(pipeType,"\t\tData size: " + ds + " " + unit + "\n");
-	
-	if(debug)
+	if(debug){	
+		//Start a timer for physical time passed during the pipe's function
+		auto startTime = std::chrono::high_resolution_clock::now();
+		
+		runPipe(inData);
+		
+		//Stop the timer for time passed during the pipe's function
+		auto endTime = std::chrono::high_resolution_clock::now();
+		
+		//Calculate the duration (physical time) for the pipe's function
+		std::chrono::duration<double, std::milli> elapsed = endTime - startTime;
+		
+		//Output the time and transient memory used for this pipeline segment
+		ut.writeLog(pipeType,"\tPipeline " + pipeType + " executed in " + std::to_string(elapsed.count()/1000.0) + " seconds (physical time)");
+		
+		auto dataSize = inData.getSize();
+		auto unit = "B";
+		
+		//Convert large datatypes (GB, MB, KB)
+		if(dataSize > 1000000000){
+			//Convert to GB
+			dataSize = dataSize/1000000000;
+			unit = "GB";
+		} else if(dataSize > 1000000){
+			//Convert to MB
+			dataSize = dataSize/1000000;
+			unit = "MB";
+		} else if (dataSize > 1000){
+			//Convert to KB
+			dataSize = dataSize/1000;
+			unit = "KB";
+		}
+		
+		inData.stats += pipeType + "," + std::to_string(elapsed.count()/1000.0) + "," + std::to_string(dataSize) + "," + unit + "," + std::to_string(inData.complex->vertexCount()) + "," + std::to_string(inData.complex->simplexCount()) + "\n";
+		
+		std::string ds = std::to_string(dataSize);
+		ut.writeLog(pipeType,"\t\tData size: " + ds + " " + unit + "\n");
 		outputData(inData);
+	} else {
+		runPipe(inData);
+	}
 	
 	return;
 }
@@ -131,7 +134,7 @@ bool basePipe::configPipe(std::map<std::string, std::string> &configMap){
 
 	auto pipe = configMap.find("debug");
 	if(pipe != configMap.end())
-		debug = std::atoi(configMap["debug"].c_str());
+		debug = (std::atoi(configMap["debug"].c_str()) > 0 ? true : false);
 	
 	return true;
 }

--- a/Pipes/basePipe.cpp
+++ b/Pipes/basePipe.cpp
@@ -68,7 +68,7 @@ void basePipe::runPipeWrapper(pipePacket &inData){
 	//Calculate the duration (physical time) for the pipe's function
 	std::chrono::duration<double, std::milli> elapsed = endTime - startTime;
 	
-	//Output the time and memory used for this pipeline segment
+	//Output the time and transient memory used for this pipeline segment
 	ut.writeLog(pipeType,"\tPipeline " + pipeType + " executed in " + std::to_string(elapsed.count()/1000.0) + " seconds (physical time)");
 	
 	auto dataSize = inData.getSize();
@@ -117,8 +117,6 @@ void basePipe::outputData(pipePacket &inData){
 	file.close();
 	return;
 }
-	
-
 
 // runPipe -> Run the configured functions of this pipeline segment
 void basePipe::runPipe(pipePacket &inData){

--- a/Pipes/basePipe.hpp
+++ b/Pipes/basePipe.hpp
@@ -12,7 +12,7 @@ class basePipe {
 	std::string fnmod = "";
 	utils ut;
 	std::string pipeType = "basePipe";
-	int debug = 0;
+	bool debug = 0;
 	std::string outputFile;
     basePipe(){};
     static basePipe* newPipe(const std::string&, const std::string&);

--- a/Pipes/pipePacket.cpp
+++ b/Pipes/pipePacket.cpp
@@ -22,19 +22,57 @@ pipePacket::pipePacket(std::map<std::string, std::string> configMap, const std::
 	complex = simplexBase::newSimplex(simplexType, configMap);
 }
 
+std::string pipePacket::getStats(){
+	std::string ret;
+	ret += std::to_string(inputData.size()) + ",";
+	ret += std::to_string(complex->simplexCount());
+	
+	return ret;
+}
+
 double pipePacket::getSize(){
-	
-	//Calculate size of original data
-	
 	size_t size = 0;
 	
+	//1. Calculate size of original data
 	for(auto row : workData){
-		for(auto index : row)
-			size += sizeof(index);
-	}	
+		size += row.size() * sizeof(row[0]);
+	}
 	
-	//Calculate size of complex storage
+	//2. Calculate size of input data
+	for(auto row : inputData){
+		size += row.size() * sizeof(row[0]);
+	}
+	
+	//3. Calculate size of centroid labels
+	size += centroidLabels.size() * sizeof(centroidLabels[0]);
+	
+	//4. Calculate size of the distance matrix
+	for(auto row : distMatrix){
+		size += row.size() * sizeof(row[0]);
+	}
+	
+	//5. Calculate size of complex storage
 	size += complex->getSize();
+	
+	//6. Calculate size of the boundaries
+	for(auto row : boundaries){
+		size += row.size() * sizeof(row.begin());
+	}
+	
+	//7. Calculate size of weights
+	size += weights.size() * sizeof(weights.begin());
+	
+	
+	//8. Calculate size of bettiTable
+	for(auto betti : bettiTable){
+		size += betti.getSize();
+	}
+	
+	//9. Calculate size of stats
+	size += stats.size() * sizeof(std::string);
+	
+	//10. Calculate size of runLog
+	size += runLog.size() * sizeof(std::string);
 	
 	return size;
 }

--- a/Pipes/pipePacket.hpp
+++ b/Pipes/pipePacket.hpp
@@ -11,10 +11,12 @@ class pipePacket {
   private:
   public:
 	std::vector<bettiBoundaryTableEntry> bettiTable;
+	std::string ident;
   
 	pipePacket(const std::string &, const double, const int);
 	pipePacket(std::map<std::string, std::string>, const std::string&);
 	std::string stats;
+	std::string runLog;
   
 	std::vector<std::vector<double>> workData;
 	std::vector<unsigned> centroidLabels;
@@ -27,5 +29,6 @@ class pipePacket {
 	std::string bettiOutput;
 	
 	double getSize();	
+	std::string getStats();
 };
 

--- a/Preprocessing/denStream.cpp
+++ b/Preprocessing/denStream.cpp
@@ -89,7 +89,7 @@ denStream::denStream(){
 
 
 // runPipe -> Run the configured functions of this pipeline segment
-pipePacket denStream::runPreprocessor(pipePacket inData){
+void denStream::runPreprocessor(pipePacket& inData){
   /////////constants//////////
   initPoints = 1000; // points to generate p clusters (large data sets, use 1000) 
   minPoints = 20; //For DBSCAN 
@@ -160,7 +160,7 @@ pipePacket denStream::runPreprocessor(pipePacket inData){
   }
 
   inData.workData = centers;
-	return inData;
+	return;
 }
 
 //Index of nearest p-micro-cluster
@@ -228,7 +228,7 @@ void denStream::merging(std::vector<std::vector<double>> &data, int p, int times
   
 
 // configPipe -> configure the function settings of this pipeline segment
-bool denStream::configPreprocessor(std::map<std::string, std::string> configMap){
+bool denStream::configPreprocessor(std::map<std::string, std::string> &configMap){
   std::string strDebug;
   
   auto pipe = configMap.find("debug");

--- a/Preprocessing/denStream.hpp
+++ b/Preprocessing/denStream.hpp
@@ -45,6 +45,6 @@ class denStream : public preprocessor {
   	
 	public:
 		denStream();
-		pipePacket runPreprocessor(pipePacket inData);
-		bool configPreprocessor(std::map<std::string, std::string> configMap);
+		void runPreprocessor(pipePacket&);
+		bool configPreprocessor(std::map<std::string, std::string>&);
 }; 

--- a/Preprocessing/kMeansPlusPlus.cpp
+++ b/Preprocessing/kMeansPlusPlus.cpp
@@ -25,10 +25,10 @@ kMeansPlusPlus::kMeansPlusPlus(){
 
 
 // runPipe -> Run the configured functions of this pipeline segment
-pipePacket kMeansPlusPlus::runPreprocessor(pipePacket inData){
+void kMeansPlusPlus::runPreprocessor(pipePacket& inData){
 	if(!configured){
 		ut.writeLog(procName,"Preprocessor not configured");
-		return inData;
+		return;
 	}
 	
     //Arguments - num_clusters, num_iterations
@@ -148,16 +148,16 @@ pipePacket kMeansPlusPlus::runPreprocessor(pipePacket inData){
 	//Assign to the pipepacket
 	inData.workData = centroids;
 	inData.centroidLabels = lastLabels;
-	return inData;
+	return;
 }
 
 // configPipe -> configure the function settings of this pipeline segment
-bool kMeansPlusPlus::configPreprocessor(std::map<std::string, std::string> configMap){
+bool kMeansPlusPlus::configPreprocessor(std::map<std::string, std::string>& configMap){
 	std::string strDebug;
 	
 	auto pipe = configMap.find("debug");
 	if(pipe != configMap.end()){
-		debug = std::atoi(configMap["debug"].c_str());
+		debug = (std::atoi(configMap["debug"].c_str()) > 0 ? true : false);
 		strDebug = configMap["debug"];
 	}
 	pipe = configMap.find("outputFile");

--- a/Preprocessing/kMeansPlusPlus.cpp
+++ b/Preprocessing/kMeansPlusPlus.cpp
@@ -144,7 +144,6 @@ void kMeansPlusPlus::runPreprocessor(pipePacket& inData){
 		
 	}
     
-	std::cout << "Clustered data..." << std::endl;
 	//Assign to the pipepacket
 	inData.workData = centroids;
 	inData.centroidLabels = lastLabels;

--- a/Preprocessing/kMeansPlusPlus.hpp
+++ b/Preprocessing/kMeansPlusPlus.hpp
@@ -11,7 +11,7 @@ class kMeansPlusPlus : public preprocessor {
 	int num_iterations;			
   public:
 	kMeansPlusPlus();
-    pipePacket runPreprocessor(pipePacket inData);
-    bool configPreprocessor(std::map<std::string, std::string> configMap);
+    void runPreprocessor(pipePacket&);
+    bool configPreprocessor(std::map<std::string, std::string>&);
 };
 

--- a/Preprocessing/preprocessor.cpp
+++ b/Preprocessing/preprocessor.cpp
@@ -85,8 +85,7 @@ void preprocessor::runPreprocessorWrapper(pipePacket &inData){
 		
 		inData.stats += procName + "," + std::to_string(elapsed.count()/1000.0) + "\n"; // + "," + std::to_string(dataSize) + "," + unit + "\n";
 		
-		outputData(inData.workData);
-		outputData(inData.centroidLabels);
+		outputData(inData);
 	
 	} else {
 		runPreprocessor(inData);
@@ -104,6 +103,15 @@ void preprocessor::outputData(std::vector<unsigned> data){
 	return;
 }
 	
+void preprocessor::outputData(pipePacket &data){
+	
+	outputData(data.workData);
+	outputData(data.centroidLabels);
+	
+	return;
+	
+	
+}
 
 // outputData -> used for tracking each stage of the pipeline's data output without runtime
 void preprocessor::outputData(std::vector<std::vector<double>> data){

--- a/Preprocessing/preprocessor.cpp
+++ b/Preprocessing/preprocessor.cpp
@@ -37,54 +37,60 @@ preprocessor* preprocessor::newPreprocessor(const std::string &procName){
 }
 
 // runPipeWrapper -> wrapper for timing of runPipe and other misc. functions
-pipePacket preprocessor::runPreprocessorWrapper(pipePacket inData){
+void preprocessor::runPreprocessorWrapper(pipePacket &inData){
 	
+	//Check if the preprocessor has been configured
 	if(!configured){
-		ut.writeLog(procName,"Preprocessor not configured");
-		return inData;
+		ut.writeLog(procName,"Pipe not configured");
+		std::cout << "Pipe not configured" << std::endl;
+		return;
 	}
 	
-	//Start a timer for physical time passed during the pipe's function
-	auto startTime = std::chrono::high_resolution_clock::now();
+	if(debug){
+		
+		//Start a timer for physical time passed during the pipe's function
+		auto startTime = std::chrono::high_resolution_clock::now();
+		
+		runPreprocessor(inData);
+		
+		//Stop the timer for time passed during the pipe's function
+		auto endTime = std::chrono::high_resolution_clock::now();
+		
+		//Calculate the duration (physical time) for the pipe's function
+		std::chrono::duration<double, std::milli> elapsed = endTime - startTime;
+		
+		//Output the time and memory used for this pipeline segment
+		std::cout << "\tPipeline " << procName << " executed in " << (elapsed.count()/1000.0) << " seconds (physical time)" << std::endl << std::endl;
+		
+		auto dataSize = inData.getSize();
+		auto unit = "B";
+		
+		std::cout << "Test" << std::endl;
+		//Convert large datatypes (GB, MB, KB)
+		if(dataSize > 1000000000){
+			//Convert to GB
+			dataSize = dataSize/1000000000;
+			unit = "GB";
+		} else if(dataSize > 1000000){
+			//Convert to MB
+			dataSize = dataSize/1000000;
+			unit = "MB";
+		} else if (dataSize > 1000){
+			//Convert to KB
+			dataSize = dataSize/1000;
+			unit = "KB";
+		}
+		
+		std::cout << "\tData size: " << dataSize << " " << unit << std::endl << std::endl;
+		
+		inData.stats += procName + "," + std::to_string(elapsed.count()/1000.0) + "\n"; // + "," + std::to_string(dataSize) + "," + unit + "\n";
+		
+		outputData(inData.workData);
+		outputData(inData.centroidLabels);
 	
-	inData = runPreprocessor(inData);
-	
-	//Stop the timer for time passed during the pipe's function
-	auto endTime = std::chrono::high_resolution_clock::now();
-	
-	//Calculate the duration (physical time) for the pipe's function
-	std::chrono::duration<double, std::milli> elapsed = endTime - startTime;
-	
-	//Output the time and memory used for this pipeline segment
-	std::cout << "\tPipeline " << procName << " executed in " << (elapsed.count()/1000.0) << " seconds (physical time)" << std::endl << std::endl;
-	
-	/*auto dataSize = inData.getSize();
-	auto unit = "B";
-	
-	std::cout << "Test" << std::endl;
-	//Convert large datatypes (GB, MB, KB)
-	if(dataSize > 1000000000){
-		//Convert to GB
-		dataSize = dataSize/1000000000;
-		unit = "GB";
-	} else if(dataSize > 1000000){
-		//Convert to MB
-		dataSize = dataSize/1000000;
-		unit = "MB";
-	} else if (dataSize > 1000){
-		//Convert to KB
-		dataSize = dataSize/1000;
-		unit = "KB";
+	} else {
+		runPreprocessor(inData);
 	}
-	
-	std::cout << "\tData size: " << dataSize << " " << unit << std::endl << std::endl;
-	*/
-	inData.stats += procName + "," + std::to_string(elapsed.count()/1000.0) + "\n"; // + "," + std::to_string(dataSize) + "," + unit + "\n";
-	
-	outputData(inData.workData);
-	outputData(inData.centroidLabels);
-	
-	return inData;
 }
 
 void preprocessor::outputData(std::vector<unsigned> data){
@@ -116,18 +122,17 @@ void preprocessor::outputData(std::vector<std::vector<double>> data){
 }
 	
 // runPipe -> Run the configured functions of this pipeline segment
-pipePacket preprocessor::runPreprocessor(pipePacket inData){
+void preprocessor::runPreprocessor(pipePacket &inData){
 	
 	std::cout << "No run function defined for: " << procName << std::endl;
 	
-	return inData;
+	return;
 }	
 
 // configPipe -> configure the function settings of this pipeline segment
-bool preprocessor::configPreprocessor(std::map<std::string, std::string> configMap){
-	
+bool preprocessor::configPreprocessor(std::map<std::string, std::string> &configMap){
 	std::cout << "No configure function defined for: " << procName << std::endl;
 	
-	return true;
+	return false;
 }
 

--- a/Preprocessing/preprocessor.cpp
+++ b/Preprocessing/preprocessor.cpp
@@ -81,9 +81,7 @@ void preprocessor::runPreprocessorWrapper(pipePacket &inData){
 			unit = "KB";
 		}
 		
-		std::cout << "\tData size: " << dataSize << " " << unit << std::endl << std::endl;
-		
-		inData.stats += procName + "," + std::to_string(elapsed.count()/1000.0) + "\n"; // + "," + std::to_string(dataSize) + "," + unit + "\n";
+		inData.stats += procName + "," + std::to_string(elapsed.count()/1000.0) + "," + std::to_string(dataSize) + "," + unit + "\n";
 		
 		outputData(inData);
 	

--- a/Preprocessing/preprocessor.hpp
+++ b/Preprocessing/preprocessor.hpp
@@ -16,6 +16,7 @@ class preprocessor {
     static preprocessor* newPreprocessor(const std::string&);
     void runPreprocessorWrapper(pipePacket &inData);
     virtual void runPreprocessor(pipePacket &inData);
+    virtual void outputData(pipePacket&);
 	virtual void outputData(std::vector<unsigned>);
 	virtual void outputData(std::vector<std::vector<double>>);
     virtual bool configPreprocessor(std::map<std::string, std::string> &configMap);

--- a/Preprocessing/preprocessor.hpp
+++ b/Preprocessing/preprocessor.hpp
@@ -9,15 +9,15 @@ class preprocessor {
   public:
 	bool configured = false;
 	std::string procName = "preprocessor";
-	int debug;
+	bool debug = 0;
 	std::string outputFile;
 	utils ut;
     preprocessor();
     static preprocessor* newPreprocessor(const std::string&);
-    pipePacket runPreprocessorWrapper(pipePacket inData);
-    virtual pipePacket runPreprocessor(pipePacket inData);
+    void runPreprocessorWrapper(pipePacket &inData);
+    virtual void runPreprocessor(pipePacket &inData);
 	virtual void outputData(std::vector<unsigned>);
 	virtual void outputData(std::vector<std::vector<double>>);
-    virtual bool configPreprocessor(std::map<std::string, std::string> configMap);
+    virtual bool configPreprocessor(std::map<std::string, std::string> &configMap);
 };
 

--- a/Preprocessing/streamingKmeans.cpp
+++ b/Preprocessing/streamingKmeans.cpp
@@ -28,11 +28,11 @@ streamingKmeans::streamingKmeans(){
 
 
 // runPipe -> Run the configured functions of this pipeline segment
-pipePacket streamingKmeans::runPreprocessor(pipePacket inData){
+void streamingKmeans::runPreprocessor(pipePacket &inData){
 	
 	if(!configured){
 		ut.writeLog(procName,"Preprocessor not configured");
-		return inData;
+		return;
 	}
 	
 	//Arguments - num_clusters, num_iterations
@@ -292,14 +292,14 @@ std::vector<std::vector<double>> summedCentroidVectors(numClusters, std::vector<
 
 
 	inData.workData = finalClusters;	
-	return inData;	
+	return;	
 }
 
 
 
 
 // configPipe -> configure the function settings of this pipeline segment
-bool streamingKmeans::configPreprocessor(std::map<std::string, std::string> configMap){
+bool streamingKmeans::configPreprocessor(std::map<std::string, std::string> &configMap){
 	std::string strDebug;
 	
 	auto pipe = configMap.find("debug");

--- a/Preprocessing/streamingKmeans.hpp
+++ b/Preprocessing/streamingKmeans.hpp
@@ -11,15 +11,15 @@ class streamingKmeans : public preprocessor {
   	
   public:
 	streamingKmeans();
-  double dotProd(const std::vector<double>& a, const std::vector<double>& b);
-  double dotProd2D(std::vector<std::vector<double>>& a, std::vector<std::vector<double>> & b);
-  std::vector<double> approxNearestNeighbor(std::vector<std::vector<double>>& facilities, std::vector<std::pair <double, int>>& sortedApproxFacils,  std::vector<double> omega, int x, int size, pipePacket(inData));
-std::vector<double> approxHat(std::vector<std::vector<double>>& summedCentroidVectors, std::vector<std::pair <double, int>>& sortedApproxFacilsHat, std::vector<double> omega, int xHat, int size);
-  int binarySearch( std::vector<std::pair<double, int>>& sorted, std::vector<double> omega, int n, double target);
-  double randDouble(); // Returns a random double in the range [0,1)
-  bool prob(double f); 
-  int random(int low, int high);   // returns random int in the range [low, high)
+	double dotProd(const std::vector<double>& a, const std::vector<double>& b);
+	double dotProd2D(std::vector<std::vector<double>>& a, std::vector<std::vector<double>> & b);
+	std::vector<double> approxNearestNeighbor(std::vector<std::vector<double>>& facilities, std::vector<std::pair <double, int>>& sortedApproxFacils,  std::vector<double> omega, int x, int size, pipePacket(inData));
+	std::vector<double> approxHat(std::vector<std::vector<double>>& summedCentroidVectors, std::vector<std::pair <double, int>>& sortedApproxFacilsHat, std::vector<double> omega, int xHat, int size);
+	int binarySearch( std::vector<std::pair<double, int>>& sorted, std::vector<double> omega, int n, double target);
+	double randDouble(); // Returns a random double in the range [0,1)
+	bool prob(double f); 
+	int random(int low, int high);   // returns random int in the range [low, high)
 
-pipePacket runPreprocessor(pipePacket inData);
-bool configPreprocessor(std::map<std::string, std::string> configMap);
+	void runPreprocessor(pipePacket&);
+	bool configPreprocessor(std::map<std::string, std::string>&);
 }; 

--- a/Utils/utils.hpp
+++ b/Utils/utils.hpp
@@ -40,6 +40,10 @@ struct bettiBoundaryTableEntry{
 	double birth;
 	double death;
 	std::set<unsigned> boundaryPoints;
+	
+	double getSize(){ 
+		return (sizeof(double)*2) + ((boundaryPoints.size() + 1) * sizeof(unsigned)); 
+	} 
 }; 
 
 

--- a/Utils/writeOutput.cpp
+++ b/Utils/writeOutput.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <iostream>
 #include <vector>
+#include <ctime>
 #include <regex>
 #include <fstream>
 #include "writeOutput.hpp"
@@ -23,10 +24,19 @@ writeOutput::writeOutput(){
 // writeStat -> write the pipeline statistics to a csv formatted file
 bool writeOutput::writeStats(std::string stats, std::string filename){
 	std::ofstream file(filename + "_stats.csv");
-	file << "PipeName,PhysExecutionTime,MemorySize,MemoryUnits,VertexCount,SimplexCount\n";
+	file << "PipeName,PhysExecutionTime,TransientMemorySize,MemoryUnits,VertexCount,SimplexCount\n";
 	file << stats;
 	file.close();
 	return true;	
+}
+
+// writeRunLog -> write the run log to a csv formatted file
+bool writeOutput::writeRunLog(std::string stats, std::string filename){
+	std::ofstream file(filename + "_runLog.csv");
+	file << "Timestamp,Process_#,Workload_#,PointSize,simplexCount,runtime(s),Arguments...\n";
+	file << stats;
+	file.close();
+	return true;
 }
 
 bool writeOutput::writeBarcodes(std::vector<bettiBoundaryTableEntry> data, std::string filename){
@@ -107,16 +117,28 @@ bool writeOutput::writeMAT(std::vector<std::vector<double>> data, std::string fi
 	return true;
 }
 
-/*
+
 // writeConsole -> write data input to console (hopefully pretty-print)
-bool writeOutput::writeConsole(pipePacket* workData){
-	std::vector<std::vector<double>> result;
+bool writeOutput::writeConsole(std::vector<bettiBoundaryTableEntry> data){
+	std::cout << "dimension,birth,death" << std::endl;
 	
-	std::cout << "_________Persistent Homology OUTPUT__________" << std::endl;
-		
-	std::cout << workData->bettiOutput << std::endl;
-	
+	for(auto row : data)
+		std::cout << std::to_string(row.bettiDim) << "," << std::to_string(row.birth) << "," << std::to_string(row.death) << std::endl;
+	std::cout << std::endl;
 	return true;
+}
+
+std::string writeOutput::logRun(std::map<std::string, std::string> args, std::string ident, std::string wdStats, std::string runtime){
+	//Get current time
+	auto res = std::time(nullptr);
+	
+	std::string ret = std::to_string(res) + "," + ident + "," + wdStats + "," + runtime + ",";
+	
+	for(auto arg : args)
+		ret += arg.first + ":" + arg.second + ",";
+	
+	ret += "\n";
+	
+	return ret;
 	
 }
-*/

--- a/Utils/writeOutput.hpp
+++ b/Utils/writeOutput.hpp
@@ -8,12 +8,14 @@ class writeOutput {
   public:
     writeOutput();
     static bool writeStats(std::string, std::string);
+    static bool writeRunLog(std::string, std::string);
     static bool writeCSV(std::string, std::string);
     static bool writeCSV(std::string, std::string, std::string);
     static bool writeCSV(std::vector<std::vector<double>>, std::string);
     static bool writeCSV(std::vector<std::vector<double>>, std::string, std::string);
     static bool writeMAT(std::vector<std::vector<double>>, std::string);
     static bool writeBarcodes(std::vector<bettiBoundaryTableEntry>, std::string);
-    //bool writeConsole(pipePacket*);
+    static bool writeConsole(std::vector<bettiBoundaryTableEntry>);
+    static std::string logRun(std::map<std::string, std::string>, std::string, std::string, std::string);
 };
 


### PR DESCRIPTION
Updated all stats files (stats, runLog, debug) to only output with debug mode turned on (-x 1 | --debug 1 ; default=0).

Removed timing and statistics for non-debug mode (-x 0) to slightly improve runtime (no console printing, no timing, no memory statistics)

Began updating some of the memory measurements, specifically the pipePacket object. (Note: these are transient memory measurements; i.e. the amount of memory passed between the pipes. Use an external program (/usr/bin/time) to get maxResident memory of the approach.)

Reworked preprocessor virtual functions to match pipeline approach, fixed issue #8 .

Added runLog to track individual thread performance and various statistics (not yet working for OpenMPI). 